### PR TITLE
Remove "Upgrading" section from "Getting Started"

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -22,8 +22,6 @@ docs:
         url: /docs/quick-start-guide
       - title: 'Installation'
         url: /docs/installation
-      - title: 'Upgrading'
-        url: /docs/upgrading
   - title: 'Orbital Work Flow'
     children:
       - title: 'Mockdefinition'


### PR DESCRIPTION
This PR removes the getting started section from the menu bar. 