### PR TITLE
update in landing page

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,7 +1,7 @@
 # main links
 main:
   - title: 'About Us'
-    url: '/about'
+    url: '/docs/about-us'
   - title: 'Documentation'
     url: '/docs/quick-start-guide'
   - title: 'Git'

--- a/_pages/docs/about-us.md
+++ b/_pages/docs/about-us.md
@@ -21,7 +21,7 @@ against a mocked API that doesn't exist yet. Or better yet, testing edge cases t
 by mocking them out. How will your application react?
 
 
- Orbital is an HTTP mocking framework that enables teams to achieve rapid software development and testing. Orbital supports mocking
+ Orbital is an HTTP mocking tool that enables enables rapid microservice development and testing. Orbital supports mocking
  services by using the OpenApi specification files in both YAML and JSON.
  Orbital allows for parallel development between front-end and back-end teams by reducing the dependency between each other. This reduces 
  idle time and creates a more flexible and dynamic development workspace.

--- a/_pages/index.markdown
+++ b/_pages/index.markdown
@@ -11,7 +11,7 @@ header:
     - label: "Get Started"
       url: "docs/quick-start-guide"
   caption: ""
-excerpt: "Orbital is an HTTP mocking framework that enables teams to achieve rapid software development and testing"
+excerpt: "Orbital is an HTTP mocking tool that enables enables rapid microservice development and testing"
 feature_row:
   - image_path:
     title: "Request Matching Rules"


### PR DESCRIPTION
things done in this branch:
* fix broken link to About Us page
* change from "Orbital is an HTTP mocking framework that enables teams to achieve rapid software development and testing" to "Orbital is an HTTP mocking tool that enables enables rapid microservice development and testing"