### PR TITLE
"General notes throughout the website"

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -31,7 +31,7 @@ docs:
         url: /docs/headersrules
       - title: 'Query Rules'
         url: /docs/queryrules
-      - title: 'Url Rules'
+      - title: 'URL Rules'
         url: /docs/urlrules
       - title: 'Body Rules'
         url: /docs/bodyrules

--- a/_pages/docs/architecture/server.md
+++ b/_pages/docs/architecture/server.md
@@ -3,12 +3,11 @@ layout: single
 title: Architecture of Orbital's Server
 permalink: /docs/architecture/server
 sidebar:
-  nav: "docs"
+  nav: 'docs'
 classes: wide
 ---
 
-Server
-------
+## Server
 
 The purpose of the server is to provide an endpoint onto which the scenarios can be run for each endpoint. Furthermore, it also stores Mockdefinitions (which can then be downloaded by the designer to be re-edited if required.)
 
@@ -20,13 +19,13 @@ Figure 1. High-level architecture diagram of the server.
 
 ### Sample message flow
 
--   The user requests “[*http://localhost:5000/pets/sammy*](http://localhost:5000/pets/sammy)”
+- The user requests “[_http://localhost:5000/pets/sammy_](http://localhost:5000/pets/sammy)”.
 
--   The request goes to the server’s middleware, and the middleware determines that it is not the admin endpoint, and so gathers all scenarios from all uploaded Mockdefinitions
+- The request goes to the server’s middleware, and the middleware determines that it is not the admin endpoint, and so gathers all scenarios from all uploaded Mockdefinitions.
 
--   The list of scenarios are passed to the Message Processor Input
+- The list of scenarios are passed to the Message Processor Input.
 
--   From there, see the section *Matching an endpoint/scenario* for more information regarding how a request is matched
+- From there, see the section _Matching an endpoint/scenario_ for more information regarding how a request is matched.
 
 ### Matching an endpoint/scenario
 
@@ -36,82 +35,83 @@ A new scenario which matches all requests (also called a failsafe) will be added
 
 These are the rules which determine when a scenario or endpoint is matched:
 
-1.  The client requests an endpoint on the server (for example /pets/sammy, when the user navigates to [*http://localhost:5000/pets/sammy*](http://localhost:5000/pets/sammy).) The request URL always begins with a slash.
+1.  The client requests an endpoint on the server (for example /pets/sammy, when the user navigates to [_http://localhost:5000/pets/sammy_](http://localhost:5000/pets/sammy).) The request URL always begins with a slash.
 
-2.  The client’s request (URL and method type) are matched against a list of endpoints. These endpoints are part of the server’s Mockdefinition, which the user has uploaded. See the *Which Mockdefinition is matched?* section for more information. The Equality URL Rules apply (except for a URL matching rule, which matches it exactly.) The method type must match exactly in order for the endpoints’ scenarios to consider matching (for example a GET request.) Additionally, the following rules apply depending on the endpoint type:
+2.  The client’s request (URL and method type) are matched against a list of endpoints. These endpoints are part of the server’s Mockdefinition, which the user has uploaded. See the _Which Mockdefinition is matched?_ section for more information. The Equality URL Rules apply (except for a URL matching rule, which matches it exactly.) The method type must match exactly in order for the endpoints’ scenarios to consider matching (for example a GET request.) Additionally, the following rules apply depending on the endpoint type:
 
     1.  If the endpoint is parameterized, see section [How parameterized endpoints are matched](#how-parameterized-endpoints-are-matched) for more information. If the endpoint is not parameterized, then it will be matched according to the Equality URL Rules definition.
 
     2.  Depending on how many endpoints match from the previous step:
 
-        1.  If **zero** endpoints match, then return an error and do not continue to the next step
+        1.  If **zero** endpoints match, then return an error and do not continue to the next step.
 
-        2.  If **only one** endpoint matches, then return a collection of scenarios for that endpoint which matches for the next step
+        2.  If **only one** endpoint matches, then return a collection of scenarios for that endpoint which matches for the next step.
 
-        3.  If **more than one** endpoints match (e.g. a parameterized endpoint), including the method types for those endpoints, then a union of all matching endpoints’ scenarios are returned for the next step
+        3.  If **more than one** endpoints match (e.g. a parameterized endpoint), including the method types for those endpoints, then a union of all matching endpoints’ scenarios are returned for the next step.
 
     3.  From this collection of returned endpoints:
 
-        1.  See section [How the response selector works](#how-the-response-selector-works)
+        1.  See section [How the response selector works](#how-the-response-selector-works).
 
 ### How parameterized endpoints are matched
 
 Orbital does not implement 100% of the OpenAPI spec. Additionally, there are some modifications to the default behavior of how endpoints match which are different than how the OpenAPI spec suggests. These differences are described as follows:
 
--   All parameters must be in the URL as in the endpoint. For example, the URL [*http://localhost/pets/1/2*](http://localhost/pets/1/2) would not match /pets/{id}/{id2}/{id3}, because {id3} is missing. The required attribute in the OpenAPI spec is ignored.
+- All parameters must be in the URL as in the endpoint. For example, the URL [_http://localhost/pets/1/2_](http://localhost/pets/1/2) would not match /pets/{id}/{id2}/{id3}, because {id3} is missing. The required attribute in the OpenAPI spec is ignored.
 
--   If there are enough parameters specified to fulfill all parameterizations, then the URL will be matched and the other paths will be optional. For example, the URL “[*https://localhost:5001/pet/uploadImage*](https://localhost:5001/pet/uploadImage)” matches the endpoint /pet/**{petId}**/uploadImage (here, uploadImage is used in place of {petId}), however /pet/uploadImage/**test** does not because **uploadImage** is automatically considered optional but still has to be fully specified or not specified at all; **test** is not exactly equal to an empty string or **uploadImage**)
+- If there are enough parameters specified to fulfill all parameterizations, then the URL will be matched and the other paths will be optional. For example, the URL “[_https://localhost:5001/pet/uploadImage_](https://localhost:5001/pet/uploadImage)” matches the endpoint /pet/**{petId}**/uploadImage (here, uploadImage is used in place of {petId}), however /pet/uploadImage/**test** does not because **uploadImage** is automatically considered optional but still has to be fully specified or not specified at all; **test** is not exactly equal to an empty string or **uploadImage**).
 
--   Here are some examples of how the paths can and cannot match, and what parameterizations are valid in the OpenAPI spec but not valid for Orbital:
+- Here are some examples of how the paths can and cannot match, and what parameterizations are valid in the OpenAPI spec but not valid for Orbital:
 
-    -   If the user requests /pets/1, /pets/xxx, /pets/xyz/, or /pets/12345 the URL /pets/{petId} will match.
+  - If the user requests /pets/1, /pets/xxx, /pets/xyz/, or /pets/12345 the URL /pets/{petId} will match.
 
-    -   If the user requests /pets/a/1, /pets/abcde/defgh, or /pets/abc/def, the URL /pets/{petId}/{adoptionId} will match.
+  - If the user requests /pets/a/1, /pets/abcde/defgh, or /pets/abc/def, the URL /pets/{petId}/{adoptionId} will match.
 
-    -   If the user requests /pets/abc/sdasd/abc, /pets/32hchd/dhdha/abc, the URL /pets/{petId}/{adoptionId}/abc will match.
+  - If the user requests /pets/abc/sdasd/abc, /pets/32hchd/dhdha/abc, the URL /pets/{petId}/{adoptionId}/abc will match.
 
-    -   Although valid in the OpenAPI spec, paths with parameters concatenated with URL components are not matched in Orbital:
+  - Although valid in the OpenAPI spec, paths with parameters concatenated with URL components are not matched in Orbital:
 
-        -   /pets/abc{petId} does not match /pets/abc1
+    - /pets/abc{petId} does not match /pets/abc1 .
 
-        -   /pets/{petId}abc does not match /pets/1abc
+    - /pets/{petId}abc does not match /pets/1abc .
 
-        -   /pets/abc{petId}def does not match /abc1def
+    - /pets/abc{petId}def does not match /abc1def .
 
-    -   Paths with parameters concatenated with other parameters are considered as a single component and not individually matched: /pets/{petId}{adoptionId} will match /pets/a
+  - Paths with parameters concatenated with other parameters are considered as a single component and not individually matched: /pets/{petId}{adoptionId} will match /pets/a .
 
-    -   Parameterization syntax is not validated, which means:
+  - Parameterization syntax is not validated, which means:
 
-        -   /pets/{petId/test} will validate successfully, matching /pets/abc, and /pets/123 and not /pets/123/456
+    - /pets/{petId/test} will validate successfully, matching /pets/abc, and /pets/123 and not /pets/123/456 .
 
-        -   /pets/{petId } will validate successfully; any character is allowed inside of the {} except for { or }.
+    - /pets/{petId } will validate successfully; any character is allowed inside of the {} except for { or }.
 
-    -   OpenAPI's type attribute (such as string or int) is ignored, and any text is allowed to be a parameter in the URL.
+  - OpenAPI's type attribute (such as string or int) is ignored, and any text is allowed to be a parameter in the URL.
 
-    -   Paths such as /test//test is the same as /test/test (n or more slashes are compacted into one when parsing the query)
+  - Paths such as /test//test is the same as /test/test (n or more slashes are compacted into one when parsing the query).
 
 ### How to determine which response is returned when multiple scenarios match an endpoint
 
--   All scenarios which match the body, query, URL, and/or header(s) are put into a single list (preserving duplicates.) For example:
-	-   request “A” has a query of “q=1” and a header of “Content-Type=text/plain”
-	-   scenario “B” that matches the query “q=1”
-	-   scenario “C” which matches “Content-Type=text/plain” for the headers
-	-   scenario “D” which matches “q=1” and “Content-Type=text/plain”
-	-   all scenarios are part of the same endpoint
-	
-	Then, both scenarios B, C, and D would be added to the lists; the header list would have C and D, the query list would have B, C, and D, etc.
+- All scenarios which match the body, query, URL, and/or header(s) are put into a single list (preserving duplicates.) For example:
 
--   The scenarios are grouped by their id (each group is now a list of scenarios, which contains the body, query, URL, and header match results.) Each one of these types (body, query, URL, and header) can be a successful match (matched exactly), failure match (did not match), or ignore match (user did not specify any rules.)
+  - request “A” has a query of “q=1” and a header of “Content-Type=text/plain”.
+  - scenario “B” that matches the query “q=1”.
+  - scenario “C” which matches “Content-Type=text/plain” for the headers.
+  - scenario “D” which matches “q=1” and “Content-Type=text/plain”.
+  - all scenarios are part of the same endpoint.
 
-    1.  Headers, queries, and bodies are matched individually; there can be multiple successful and failure matches per group in a scenario. This means if I have headers X, Y, and Z and my request has header X, then it will successfully match header X, but not header Y and Z. Similarly, if I don’t specify any headers, then any headers sent in the request will be ignored.
+  Then, both scenarios B, C, and D would be added to the lists; the header list would have C and D, the query list would have B, C, and D, etc.
 
-    2.  Headers and queries rule type (for example equals or contains) matches just the value. The key must be an exact equality match.
+- The scenarios are grouped by their id (each group is now a list of scenarios, which contains the body, query, URL, and header match results.) Each one of these types (body, query, URL, and header) can be a successful match (matched exactly), failure match (did not match), or ignore match (user did not specify any rules.)
 
-    3.  Multiple bodies can be matched in the request only if one of the match types is not textual equals or JSON equals, and there is at least one type. Warning: if the body match type is JSON equals, then the structure can only be nested up to C\#’s stack limit ([*14250*](https://rosettacode.org/wiki/Find_limit_of_recursion#C.23).) Otherwise, it will throw an error and could crash the server.
+  1.  Headers, queries, and bodies are matched individually; there can be multiple successful and failure matches per group in a scenario. This means if I have headers X, Y, and Z and my request has header X, then it will successfully match header X, but not header Y and Z. Similarly, if I don’t specify any headers, then any headers sent in the request will be ignored.
 
-    4.  To see when URL rules are matched, see section [How are URL rules matched?](#how-are-url-rules-matched)
+  2.  Headers and queries rule type (for example equals or contains) matches just the value. The key must be an exact equality match.
 
--   If a group contains a match failure (i.e. a scenario failed to match on the body, query, URL, or header) then the scenario will be discarded from the potential candidates to be returned to the user, except for headers. Headers are treated individually, which means that they are not part of the match group and so if one does not match that does not mean that the entire scenario is discarded. If the user did not specify a rule for the body, then the match type will be “ignore” and thus not failure and will not be discarded from the group.
+  3.  Multiple bodies can be matched in the request only if one of the match types is not textual equals or JSON equals, and there is at least one type. Warning: if the body match type is JSON equals, then the structure can only be nested up to C\#’s stack limit ([_14250_](https://rosettacode.org/wiki/Find_limit_of_recursion#C.23).) Otherwise, it will throw an error and could crash the server.
+
+  4.  To see when URL rules are matched, see section [How are URL rules matched?](#how-are-url-rules-matched).
+
+- If a group contains a match failure (i.e. a scenario failed to match on the body, query, URL, or header) then the scenario will be discarded from the potential candidates to be returned to the user, except for headers. Headers are treated individually, which means that they are not part of the match group and so if one does not match that does not mean that the entire scenario is discarded. If the user did not specify a rule for the body, then the match type will be “ignore” and thus not failure and will not be discarded from the group.
 
 ### How the response selector works
 
@@ -125,19 +125,19 @@ Orbital does not implement 100% of the OpenAPI spec. Additionally, there are som
 
     3.  Scenario A, B, and C are in endpoint A. Scenario D, E, F are in endpoint B. All scenarios (except A and B) match request R. Since endpoint A is above endpoint B, then all scenarios within endpoint A get precedence. Therefore, scenario C will match R.
 
-3.  If there is **only one scenario, and it partially matches** (i.e. one of the rules match the request), then it will be returned
+3.  If there is **only one scenario, and it partially matches** (i.e. one of the rules match the request), then it will be returned.
 
-4.  If there are **no scenarios defined**, then return a default response (status code 400)
+4.  If there are **no scenarios defined**, then return a default response (status code 400).
 
 5.  If there are **multiple scenarios that partially match**, then:
 
-    1.  See section (How to determine which response is returned when multiple scenarios match a request)[#how-to-determine-which-response-is-returned-when-multiple-scenarios-match-a-request]
+    1.  See section (How to determine which response is returned when multiple scenarios match a request)[#how-to-determine-which-response-is-returned-when-multiple-scenarios-match-a-request].
 
     2.  This process is repeated for all remaining scenarios.
 
     3.  Now, there is a list of scenario(s) remaining **which might be empty**:
 
-        1.  If the **list is empty**, return a default response (status code 400)
+        1.  If the **list is empty**, return a default response (status code 400).
 
         2.  If the **list is not empty**:
 
@@ -145,27 +145,27 @@ Orbital does not implement 100% of the OpenAPI spec. Additionally, there are som
 
             2.  **Sort the groups by score (greatest first)**:
 
-                1.  If **all matches are zero (or all are ignore)**, then choose the first scenario
+                1.  If **all matches are zero (or all are ignore)**, then choose the first scenario.
 
                 2.  **Otherwise**, choose the first scenario in the sorted list, then return the response from that scenario. The sorting method is stable, which means that if two items do not need to be sorted (i.e. they have the same score), then their order will not be changed. For sorting:
 
-                    1.  Scenarios near the top of the list in the designer get priority
+                    1.  Scenarios near the top of the list in the designer get priority.
 
-                    2.  Within those, headers, body, query, and URL matches get priority in that order (headers being the highest)
+                    2.  Within those, headers, body, query, and URL matches get priority in that order (headers being the highest).
 
-            3.  Return the response to the user
+            3.  Return the response to the user.
 
 ### How are URL rules matched?
 
--   Match everything after the host name. For example, [*http://localhost**/sammy/pets***](http://localhost/sammy/pets)**,** including the leading /
+- Match everything after the host name. For example, [\*http://localhost**/sammy/pets\***](http://localhost/sammy/pets)**,** including the leading / .
 
--   Cannot inherit parameterization, but endpoints can. For example, if the endpoint is “/pets/{petId}”, then specifying “{petId}” in the URL rule will not match it and would be treated as a string literal.
+- Cannot inherit parameterization, but endpoints can. For example, if the endpoint is “/pets/{petId}”, then specifying “{petId}” in the URL rule will not match it and would be treated as a string literal.
 
--   Must use a valid C\# regex when matching with regexes. For example, “\\d{0,9}” to match a digit (without quotes)
+- Must use a valid C\# regex when matching with regexes. For example, “\\d{0,9}” to match a digit (without quotes).
 
--   Can be always void matches if the URL specified does not match the endpoint, or is not partially composed of the endpoint. For example, it is possible to have a valid URL rule, but it is impossible for the scenario to match. An example of this is any URL rule whose first character is not equal to the first character of the endpoint’s URL, and the endpoint’s URL is an equality rule.
+- Can be always void matches if the URL specified does not match the endpoint, or is not partially composed of the endpoint. For example, it is possible to have a valid URL rule, but it is impossible for the scenario to match. An example of this is any URL rule whose first character is not equal to the first character of the endpoint’s URL, and the endpoint’s URL is an equality rule.
 
--   Regexes do not have a time limit; be careful when constructing the regexes. It is possible to hang the server if the regex is too complicated or the request input is very long.
+- Regexes do not have a time limit; be careful when constructing the regexes. It is possible to hang the server if the regex is too complicated or the request input is very long.
 
 ### Which Mockdefinition is matched?
 
@@ -173,19 +173,19 @@ The title of the Mockdefinition that was least recently uploaded will take prece
 
 Here are some examples (A, B, and C are identical mockdefinitions except the responses are different. “A” and “B” are the names of the Mockdefinitions):
 
--   If A is uploaded and then B, A’s endpoint matches
+- If A is uploaded and then B, A’s endpoint matches.
 
--   If B is uploaded and then A, B’s endpoint matches
+- If B is uploaded and then A, B’s endpoint matches.
 
--   If B is uploaded and then A and then C, B’s endpoint matches
+- If B is uploaded and then A and then C, B’s endpoint matches.
 
--   If B is uploaded and then A and then C then deleted A, then B’s endpoint matches (suggesting no re-ordering)
+- If B is uploaded and then A and then C then deleted A, then B’s endpoint matches (suggesting no re-ordering).
 
--   If A is uploaded and then B, and then uploaded B again, A’s endpoint matches
+- If A is uploaded and then B, and then uploaded B again, A’s endpoint matches.
 
--   If A is uploaded and then B, then uploaded A again, A’s endpoint matches
+- If A is uploaded and then B, then uploaded A again, A’s endpoint matches.
 
--   If only A is uploaded, then A’s endpoint matches
+- If only A is uploaded, then A’s endpoint matches.
 
 ### Definitions
 

--- a/_pages/docs/code-of-conduct.md
+++ b/_pages/docs/code-of-conduct.md
@@ -21,22 +21,22 @@ orientation.
 Examples of behavior that contributes to creating a positive environment
 include:
 
-- Using welcoming and inclusive language
-- Being respectful of differing viewpoints and experiences
-- Gracefully accepting constructive criticism
-- Focusing on what is best for the community
-- Showing empathy towards other community members
+- Using welcoming and inclusive language.
+- Being respectful of differing viewpoints and experiences.
+- Gracefully accepting constructive criticism.
+- Focusing on what is best for the community.
+- Showing empathy towards other community members.
 
 Examples of unacceptable behavior by participants include:
 
 - The use of sexualized language or imagery and unwelcome sexual attention or
-  advances
-- Trolling, insulting/derogatory comments, and personal or political attacks
-- Public or private harassment
+  advances.
+- Trolling, insulting/derogatory comments, and personal or political attacks.
+- Public or private harassment.
 - Publishing others' private information, such as a physical or electronic
-  address, without explicit permission
+  address, without explicit permission.
 - Other conduct which could reasonably be considered inappropriate in a
-  professional setting
+  professional setting.
 
 ## Our Responsibilities
 
@@ -75,7 +75,7 @@ members of the project's leadership.
 ## Attribution
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at [http://contributor-covenant.org/version/1/4][version]
+available at [http://contributor-covenant.org/version/1/4][version].
 
 [homepage]: http://contributor-covenant.org
 [version]: http://contributor-covenant.org/version/1/4/

--- a/_pages/docs/contributing.md
+++ b/_pages/docs/contributing.md
@@ -51,7 +51,7 @@ You found a bug. That sucks. Okay, let's get this thing fixed. Here are some ste
   - What version of RabbitMQ are you using?
 - **Attach some files.** Add log files, screenshots, even animated GIFS that might show more information about the bug.
 - **Suggest a solution.** Maybe the fix isn't obvious, but even if you're not going to code a solution we would appreciate your inclusion of the fruits of your investigation so far.
-- **Sumbit your bug.** Send us an email with all the information to the project team at [opensource@focisolutions.com](mailto:opensource@focisolutions.com)
+- **Sumbit your bug.** Send us an email with all the information to the project team at [opensource@focisolutions.com](mailto:opensource@focisolutions.com).
 
 ## Feature Suggestions
 
@@ -59,7 +59,7 @@ We know Orbital has the room for many cool new features. You see that too? Want 
 
 - As with [bugs](#bug-reporting), please **check the list** of [outstanding and in-development features](https://dev.azure.com/focisolutions/Orbital/_workitems/recentlycreated/) to make sure it hasn't already been reported.
 - **Create a descriptive and clear title.**
-- **Provide a thorough description of the feature.** Can you add a step-by-step guide? Describe each step of interaction and expected behaviour in execution.
+- **Provide a thorough description of the feature.** Can you add a step-by-step guide? Describe each step of interaction and expected behavior in execution.
 - **Explain the added value.** What priority should this feature be? Why? How would it make Orbital more useful to the most people?
 - **Include documentation.** Link to any supporting documentation that might be necessary.
 - **Label it as an enhancement.** We don't want to confuse our features and bugs.

--- a/_pages/docs/quick-start-guide/index.md
+++ b/_pages/docs/quick-start-guide/index.md
@@ -28,7 +28,7 @@ This quick start guide will show you how to make a simple petstore which returns
 17. Set the title to `Return a pet`
 18. Under &quot;Query Match Rules&quot;, type in `pet` as the key and `sammy` as the value
 19. Click &quot;+&quot; next to the entry
-20. In "Request Match Rules", remove the "Accept All" match rule in the "Url Match Rules" section. This rule is automatically added to new Mockdefinitions.
+20. In "Request Match Rules", remove the "Accept All" match rule in the "URL Match Rules" section. This rule is automatically added to new Mockdefinitions.
 21. Set the response status code to `200`
 22. Set the response body to `"Sammy the cat"` (with quotes)
 23. Click "Save"

--- a/_pages/docs/quick-start-guide/index.md
+++ b/_pages/docs/quick-start-guide/index.md
@@ -3,39 +3,39 @@ layout: single
 title: Quick-Start Guide
 permalink: /docs/quick-start-guide
 sidebar:
-  nav: "docs"
+  nav: 'docs'
 classes: wide
 ---
 
 This quick start guide will show you how to make a simple petstore which returns a pet by name. If no pets are found, it will return a custom message.
 
-1. Follow the [installation instructions](/docs/installation/) to start up the designer and server
-2. Navigate to [http://localhost:4200](http://localhost:4200) in your browser
-3. Download a sample OpenAPI v2.0 file (for example, [petstore.json](https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/examples/v2.0/json/petstore.json)
-4. Click &quot;Create new Mock&quot;
-5. Use `Pet Store Mock` as the Mockdefinition&#39;s title
-6. Use `petstore.json` as the OpenAPI file
-7. Click &quot;Next&quot;
+1. Follow the [installation instructions](/docs/installation/) to start up the designer and server.
+2. Navigate to [http://localhost:4200](http://localhost:4200) in your browser.
+3. Download a sample OpenAPI v2.0 file (for example, [petstore.json](https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/examples/v2.0/json/petstore.json).
+4. Click &quot;Create new Mock&quot;.
+5. Use `Pet Store Mock` as the Mockdefinition&#39;s title.
+6. Use `petstore.json` as the OpenAPI file.
+7. Click &quot;Next&quot;.
 8. You will be presented with a list of endpoints available in `petstore.json`. Click on &quot;GET /pets&quot;.
 9. Create a new scenario which will match all requests to the &quot;GET /pets&quot; endpoint [(http://localhost:5000/pets)](http://localhost:5000/pets), and do not match any other scenario(s) that we have provided:
-10. Click the scenario called &quot;default title for /pet&quot;
+10. Click the scenario called &quot;default title for /pet&quot;.
 11. Start by filling the "Metadata" section. Give the new scenario a new name (call it `Default Scenario`) and description. The name is required.
-12. Set the response status code to `200`
-13. Click "Response" then set the response body to `"No pets found"` (with quotes)
-14. Click &quot;Save&quot;
-15. Create another scenario which will return `Sammy the cat` when a user goes to [http://localhost:5000/pets?pet=sammy](http://localhost:5000/pets?pet=sammy) :
-16. Click &quot;+&quot; to create a new scenario
-17. Set the title to `Return a pet`
-18. Under &quot;Query Match Rules&quot;, type in `pet` as the key and `sammy` as the value
-19. Click &quot;+&quot; next to the entry
+12. Set the response status code to `200`.
+13. Click "Response" then set the response body to `"No pets found"` (with quotes).
+14. Click &quot;Save&quot;.
+15. Create another scenario which will return `Sammy the cat` when a user goes to [http://localhost:5000/pets?pet=sammy](http://localhost:5000/pets?pet=sammy):
+16. Click &quot;+&quot; to create a new scenario.
+17. Set the title to `Return a pet`.
+18. Under &quot;Query Match Rules&quot;, type in `pet` as the key and `sammy` as the value.
+19. Click &quot;+&quot; next to the entry.
 20. In "Request Match Rules", remove the "Accept All" match rule in the "URL Match Rules" section. This rule is automatically added to new Mockdefinitions.
-21. Set the response status code to `200`
-22. Set the response body to `"Sammy the cat"` (with quotes)
-23. Click "Save"
+21. Set the response status code to `200`.
+22. Set the response body to `"Sammy the cat"` (with quotes).
+23. Click "Save".
 24. In order for the Mockdefinition to match requests, it has to be uploaded to the Mockdefinition server. Click on &quot;Export Mock to Server&quot; in the left-hand sidebar.
-25. Move the Mockdefinition that you&#39;ve created to the right-hand side using the arrows
-26. Use [http://localhost:5000/api/v1/OrbitalAdmin](http://localhost:5000/api/v1/OrbitalAdmin) as the server URI
-27. Click &quot;Upload&quot;
+25. Move the Mockdefinition that you&#39;ve created to the right-hand side using the arrows.
+26. Use [http://localhost:5000/api/v1/OrbitalAdmin](http://localhost:5000/api/v1/OrbitalAdmin) as the server URI.
+27. Click &quot;Upload&quot;.
 28. If uploading was successful, it will say that it was successful after a few seconds and move the exported Mockdefinition to the left-hand side. If it was not successful, ensure that your server is running. For more information, refer to the Installation instructions and ensure that you can access &quot;[http://localhost:5001](http://localhost:5001)&quot; in your browser.
 29. Navigate to [http://localhost:5000/pets](http://localhost:5000/pets) in your browser. It should display `No pets found`, as we did not specify a pet.
 30. Navigate to [http://localhost:5000/pets?pet=sammy](http://localhost:5000/pets?pet=sammy) in your browser. It should display `Sammy the cat`.

--- a/_pages/docs/quick-start-guide/installing.md
+++ b/_pages/docs/quick-start-guide/installing.md
@@ -39,15 +39,15 @@ The mock definition designer will be running on `http://localhost:4200`, and the
 
 If you're running Linux, you'll need:
 
-- the [Linux .NET 2.2 SDK](https://docs.microsoft.com/dotnet/core/install/linux-package-managers)
-- the [Linux npm and the NodeJS package manager](https://nodejs.org/en/download/package-manager/)
-- git via `apt-get install git`
+- the [Linux .NET 2.2 SDK](https://docs.microsoft.com/dotnet/core/install/linux-package-managers).
+- the [Linux npm and the NodeJS package manager](https://nodejs.org/en/download/package-manager/).
+- git via `apt-get install git`.
 
 If you're running Windows, you'll need:
 
-- the [Windows .NET 2.2 SDK](https://dotnet.microsoft.com/download/dotnet-core/thank-you/sdk-2.2.100-windows-x64-installer)
-- the [Windows npm and the NodeJS package manager](https://nodejs.org/en/download/)
-- the Git [.exe installer for Windows](https://git-scm.com/download/win)
+- the [Windows .NET 2.2 SDK](https://dotnet.microsoft.com/download/dotnet-core/thank-you/sdk-2.2.100-windows-x64-installer).
+- the [Windows npm and the NodeJS package manager](https://nodejs.org/en/download/).
+- the Git [.exe installer for Windows](https://git-scm.com/download/win).
 
 ## Clone
 

--- a/_pages/docs/request-match-rules/bodyrules.md
+++ b/_pages/docs/request-match-rules/bodyrules.md
@@ -23,7 +23,7 @@ After uploading the mockdefinition to the server using the Orbital Designer, you
 tools like Postman that will meet the criteria of the scenario. Setting the body to match the rule(s) that you
 have created and receiving back the responses mocked out earlier.
 
-### Creating a url match rule in the Orbital Designer
+### Creating a URL match rule in the Orbital Designer
 
 Once a new mockdefinition is generated, you start at the Endpoint Overview. This displays the available endpoints
 along with their verbs, endpoint path and if there are any existing scenarios.
@@ -38,19 +38,19 @@ Select the endpoint to have a scenario added. There will be a default scenario t
 
 ![Scenario Overview](../../../assets/images/orbital-ui/scenariooverview.png)
 
-#### Here we have the input for adding a url match rule
+#### Here we have the input for adding a URL match rule
 
 ![URL Request Match - Request](../../../assets/images/request-match-rules/addingbodymatchrule.png)
 
 localhost:4000?Search=Orbital
 
 We have added the value of `/pets` the rule of `Equals`. This
-rule will check request url endpoint path to ensure they have the correct value.
+rule will check request URL endpoint path to ensure they have the correct value.
 
 Once a value of the request body has been added, you will need to also add a response. The response
 includes the status code and the Body of the response.
 
-Once a value and rule for the url match rule has been added, you will need to also add a response. The response
+Once a value and rule for the URL match rule has been added, you will need to also add a response. The response
 includes the status code and the body of the response.
 
 #### Here we have the response being populated

--- a/_pages/docs/request-match-rules/mockdefinition.md
+++ b/_pages/docs/request-match-rules/mockdefinition.md
@@ -25,4 +25,4 @@ should expect from the endpoint. A scenario consists of:
 - Request Match Rules: These rules will indicate what the users HTTP request has to match to get a response from the server.
 - Response: The server's response to the user's HTTP request.
 
-The request match rules include [Header rules](./headersrules), [Query rules](./queryrules), [URL rules](./urlrules) and [Body rules](./bodyrules)
+The request match rules include [Header rules](./headersrules), [Query rules](./queryrules), [URL rules](./urlrules) and [Body rules](./bodyrules).

--- a/_pages/docs/request-match-rules/mockdefinition.md
+++ b/_pages/docs/request-match-rules/mockdefinition.md
@@ -25,4 +25,4 @@ should expect from the endpoint. A scenario consists of:
 - Request Match Rules: These rules will indicate what the users HTTP request has to match to get a response from the server.
 - Response: The server's response to the user's HTTP request.
 
-The request match rules include [Header rules](./headersrules), [Query rules](./queryrules), [Url rules](./urlrules) and [Body rules](./bodyrules)
+The request match rules include [Header rules](./headersrules), [Query rules](./queryrules), [URL rules](./urlrules) and [Body rules](./bodyrules)

--- a/_pages/docs/request-match-rules/policies.md
+++ b/_pages/docs/request-match-rules/policies.md
@@ -3,7 +3,7 @@ layout: single
 title: Policies
 permalink: /docs/policies
 sidebar:
-  nav: "docs"
+  nav: 'docs'
 classes: wide
 ---
 
@@ -11,7 +11,7 @@ Policies allow certain principles and commands to run after a scenario has been 
 
 ## Adding a new policy
 
-To add a new policy, open the “Policy” dropdown in the designer
+To add a new policy, open the “Policy” dropdown in the designer.
 
 ![Policy Empty](../../../assets/images/request-match-rules/policy_empty.png)
 

--- a/_pages/docs/request-match-rules/queryrules.md
+++ b/_pages/docs/request-match-rules/queryrules.md
@@ -3,7 +3,7 @@ layout: single
 title: Query Rules
 permalink: /docs/queryrules
 sidebar:
-  nav: "docs"
+  nav: 'docs'
 classes: wide
 ---
 

--- a/_pages/docs/request-match-rules/urlrules.md
+++ b/_pages/docs/request-match-rules/urlrules.md
@@ -1,6 +1,6 @@
 ---
 layout: single
-title: Url Rules
+title: URL Rules
 permalink: /docs/urlrules
 sidebar:
   nav: "docs"
@@ -9,21 +9,21 @@ classes: wide
 
 ## What are they?
 
-In a mockdefinition file, the scenarios have a series of matching rules, these include url match rules.
+In a mockdefinition file, the scenarios have a series of matching rules, these include URL match rules.
 
-Url match rules are rules that govern the request url endpoint path property. This allows you to mock out the different
-valid and invalid endpoint path url values.
+URL match rules are rules that govern the request URL endpoint path property. This allows you to mock out the different
+valid and invalid endpoint path URL values.
 
 ## How do they work?
 
-When you add a url match rule and response, this enables you to mock out what the response is to requests with
-these chosen url match rules.
+When you add a URL match rule and response, this enables you to mock out what the response is to requests with
+these chosen URL match rules.
 
 After uploading the mockdefinition to the server using the Orbital Designer, you can now generate a request with
-tools like Postman that will replicate the scenario. Setting the url endpoint path to match the rule(s) that you
+tools like Postman that will replicate the scenario. Setting the URL endpoint path to match the rule(s) that you
 have created and receiving back the responses mocked out earlier.
 
-### Creating a url match rule in the Orbital Designer
+### Creating a URL match rule in the Orbital Designer
 
 Once a new mockdefinition is generated, you start at the Endpoint Overview. This displays the available endpoints
 along with their verbs, endpoint path and if there are any existing scenarios.
@@ -38,14 +38,14 @@ Select the endpoint to add a scenario, or update an existing one. There will be 
 
 ![Scenario Overview](../../../assets/images/orbital-ui/scenariooverview.png)
 
-#### Adding a url match rule
+#### Adding a URL match rule
 
 ![URL Request Match - Request](../../../assets/images/request-match-rules/addingurlmatchrule.png)
 
 We have added the value of `/pets` and the rule of `Equals`. This
-rule will check the request url endpoint path to ensure they have the same value.
+rule will check the request URL endpoint path to ensure they have the same value.
 
-Once a value and rule for the url match rule has been added, you will need to add a response. The response
+Once a value and rule for the URL match rule has been added, you will need to add a response. The response
 includes the status code, an optional header and the body of the response.
 
 #### Response being populated

--- a/_pages/docs/request-match-rules/urlrules.md
+++ b/_pages/docs/request-match-rules/urlrules.md
@@ -3,7 +3,7 @@ layout: single
 title: URL Rules
 permalink: /docs/urlrules
 sidebar:
-  nav: "docs"
+  nav: 'docs'
 classes: wide
 ---
 

--- a/_pages/docs/style-guide/designer_style_guide.md
+++ b/_pages/docs/style-guide/designer_style_guide.md
@@ -3,7 +3,7 @@ layout: single
 title: Orbital Designer Style Guide
 permalink: /docs/designer_style_guide/
 sidebar:
-  nav: "docs"
+  nav: 'docs'
 classes: wide
 ---
 
@@ -38,8 +38,8 @@ Think about creating a folder for a component when it has multiple accompanying 
 
 ```javascript
 /**
- * Sets the selected list to the items passed into it
- * @param items The list of items to set as selected from the left list
+ * Sets the selected list to the items passed into it.
+ * @param items The list of items to set as selected from the left list.
  */
 ```
 

--- a/_pages/docs/style-guide/server_style_guide.md
+++ b/_pages/docs/style-guide/server_style_guide.md
@@ -9,14 +9,14 @@ classes: wide
 
 Much of our style guide pulls directly from Microsoft's [C# Coding Conventions](https://docs.microsoft.com/en-us/dotnet/articles/csharp/programming-guide/inside-a-program/coding-conventions#Anchor_3). When in doubt, their documentation is a good place to look.
 
-## Guiding Principle: Consistency is king.
+## Guiding Principle: Consistency is king
 
 While we try hard to adhere to our style guide, sometimes conventions work their way into the code and just start getting used across the board. As such, we think it is most important that the code is consistent in its construction. If there is something in this style guide that is being ignored throughout the code, please follow the convention already in place. If you see something that doesn't adhere to either this guide or the code, please change it to follow the lead of the rest of the code. We're counting on everyone working together to keep our code as readable as possible.
 
 ## Naming Conventions
 
-“c” = camelCase
-“P” = PascalCase
+“c” = camelCase.
+“P” = PascalCase.
 “x” = Not Applicable.
 
 | Identifier      | Public | Protected | Internal | Private | Notes                                                                                           |
@@ -141,35 +141,35 @@ Everyone has hers or his own coding style, and everyone thinks theirs is best. G
 - Place namespace `using` statements together at the top of file. Group .NET namespaces above custom namespaces.
 - Keep lambda statements tidy. If they have more than two `.`,then indent and use multiple lines. Avoid nested lambdas if possible.
 - Group internal `class` implementation by type in the following order:
-  1.       Member variables.
-  2.       Constructors & Finalizers.
-  3.       Nested Enums, Structs, and Classes.
-  4.       Properties
-  5.       Methods
-  6.       Sequence declarations within type groups based upon access modifier and visibility:
-  - Public
-  - Protected
-  - Internal
-  - Private
+  1.         Member variables.
+  2.         Constructors & Finalizers.
+  3.         Nested Enums, Structs, and Classes.
+  4.         Properties.
+  5.         Methods.
+  6.         Sequence declarations within type groups based upon access modifier and visibility:
+  - Public.
+  - Protected.
+  - Internal.
+  - Private.
 - Use #region statements to group implementations and code when applicable.
 - Indent code within brackets.
 - Use white space (tabs, line breaks, etc) liberally to separate and organize code.
 - One attribute per line above the class declaration.
 - The following attribute declarations all get separate lines:
-  - Assembly scope
-  - Type scope
-  - Method scope
-  - Member scope
+  - Assembly scope.
+  - Type scope.
+  - Method scope.
+  - Member scope.
 - Parameter attribute declarations go inline with the parameter.
-- Do not explicitly specify a type of an `enum` or values of `enum`s
+- Do not explicitly specify a type of an `enum` or values of `enum`s:
 
 ```csharp
             // Bad!
            public enum Direction : long
            {
                North = 1,
-               East ,
-               South ,
+               East,
+               South,
                West
            }
 
@@ -183,7 +183,7 @@ Everyone has hers or his own coding style, and everyone thinks theirs is best. G
            }
 ```
 
-- Do not suffix `enum` names with `Enum`
+- Do not suffix `enum` names with `Enum`:
 
 ```csharp
            // Bad!

--- a/_pages/index.markdown
+++ b/_pages/index.markdown
@@ -1,36 +1,36 @@
 ---
-title: "Orbital"
+title: 'Orbital'
 layout: splash
 permalink: /
 date: 2016-03-23T11:48:41-04:00
 header:
-  overlay_color: "#000"
-  overlay_filter: "0.5"
+  overlay_color: '#000'
+  overlay_filter: '0.5'
   overlay_image: /assets/images/planets.jpg
   actions:
-    - label: "Get Started"
-      url: "docs/quick-start-guide"
-  caption: ""
-excerpt: "Orbital is an HTTP mocking tool that enables enables rapid microservice development and testing"
+    - label: 'Get Started'
+      url: 'docs/quick-start-guide'
+  caption: ''
+excerpt: 'Orbital is an HTTP mocking tool that enables enables rapid microservice development and testing'
 feature_row:
   - image_path:
-    title: "Request Matching Rules"
-    excerpt: "Incorporating highly flexible and customizable request matching rules, virtually any kind of request can be matched"
-    url: "docs/mockdefinition"
-    btn_label: "Read More"
-    btn_class: "btn--primary"
+    title: 'Request Matching Rules'
+    excerpt: 'Incorporating highly flexible and customizable request matching rules, virtually any kind of request can be matched.'
+    url: 'docs/mockdefinition'
+    btn_label: 'Read More'
+    btn_class: 'btn--primary'
   - image_path:
-    title: "Flexible Deployment"
-    excerpt: "Built with Docker and .NET Core, Orbital can be deployed anywhere Docker is supported, including Windows, Linux, and macOS"
-    url: "docs/installation/"
-    btn_label: "Read More"
-    btn_class: "btn--primary"
+    title: 'Flexible Deployment'
+    excerpt: 'Built with Docker and .NET Core, Orbital can be deployed anywhere Docker is supported, including Windows, Linux, and macOS.'
+    url: 'docs/installation/'
+    btn_label: 'Read More'
+    btn_class: 'btn--primary'
   - image_path:
-    title: "Server"
-    excerpt: "Orbital's modular pipeline architecture allows for easy development, request matching, and debugging"
-    url: "docs/architecture/server"
-    btn_label: "Read More"
-    btn_class: "btn--primary"
+    title: 'Server'
+    excerpt: "Orbital's modular pipeline architecture allows for easy development, request matching, and debugging."
+    url: 'docs/architecture/server'
+    btn_label: 'Read More'
+    btn_class: 'btn--primary'
 ---
 
 {% include feature_row %}


### PR DESCRIPTION
Add periods to the end of sentences, and capitalize all "url" words. This is issue 2030 on the internal tracker.