### PR TITLE
Make code block white on black for mockdefinition page

### DIFF
--- a/_pages/docs/request-match-rules/mockdefinition.md
+++ b/_pages/docs/request-match-rules/mockdefinition.md
@@ -28,7 +28,7 @@ The request match rules include [Header rules](./header-rules), [Query rules](./
 
 ### Sample mockdefinition
 
-```JSON
+```json
 {
     "metadata": {
         "title": "mockdefinition",


### PR DESCRIPTION
This PR fixes a syntax error in the code syntax formatting format. This makes the code color on the mockdefinition page the same as the homepage.