### PR TITLE
Remove unneeded dash in page titles

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -25,6 +25,7 @@ relative_permalinks: false
 title: ''
 # Outputting
 timezone: Canada/Eastern
+title_separator: ' '
 
 include:
   - _pages


### PR DESCRIPTION
This removes the dash from titles such as "Orbital -" or "Mockdefinitions -" to "Orbital" and "Mockdefinitions" respectively. The title separator has to be a space; an empty string doesn't work.