### PR TITLE
Explicitly set the masthead title to be an empty string

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -23,6 +23,8 @@ markdown: kramdown
 remote_theme: mmistakes/minimal-mistakes
 relative_permalinks: false
 title: "Orbital"
+# Remove masthead title since the logo contains the title text
+masthead_title: ""
 # Outputting
 timezone: Canada/Eastern
 title_separator: " | "


### PR DESCRIPTION
The logo already contains the title.

![image](https://user-images.githubusercontent.com/894128/165612609-3601afda-63f9-4340-a06a-eaf37c5e6e81.png)
