### PR TITLE
Updated licence page with appended current date of recent changes

### DIFF
--- a/_pages/docs/license.md
+++ b/_pages/docs/license.md
@@ -7,7 +7,7 @@ sidebar:
 classes: wide
 ---
 
-Copyright (c) 2020 Foci Solutions . All rights reserved.
+Copyright (c) 2020-2022 Foci Solutions . All rights reserved.
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 
 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.


### PR DESCRIPTION
**Changes:**
- Updated copyright page date with static number based on spike below:
![Screenshot 2022-04-28 090655](https://user-images.githubusercontent.com/101201411/165785814-6fc726aa-4960-4a81-87d6-338364dd7e8a.jpg)

**[Spike]**
src: https://www.quora.com/If-you-update-a-site-does-the-copyright-year-change
Essentially when the website was published (2020), that was it's origin date of completion/publication and any subsequent changes should reflect the latest year - **BUT not change the original year**. 

You have an option to leave it as it is: in our case `2020`, or update it to read `Copyright (c) 2020-2022 Foci Solutions`  to reflect our recent changes in this and the upcoming sprint. 

The footer date is handled by Jekyll dynamically and syncs to the current date, but I'm reading that this is a common misconception and the ideal should be `{first_published_year}-{latest_update_year}` 