### PR TITLE
Added missing package due to dependency with Ruby > 3.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,4 +14,5 @@ group :jekyll_plugins do
   gem "jemoji"
   gem "jekyll-include-cache"
   gem "jekyll-algolia"
+  gem "webrick"
 end


### PR DESCRIPTION
**Changes**
- Updated `webrick` on local environments serving Jekyll pages based on Spike below: 
- Error encountered without dependency:

![Screenshot 2022-04-28 093212](https://user-images.githubusercontent.com/101201411/165789395-8b66c18e-8555-4fe9-a04d-feb1fcc06050.jpg)


**[Spike]**
- https://github.com/jekyll/jekyll/issues/8523